### PR TITLE
[@types/react-css-modules] fix TypeOptions interface

### DIFF
--- a/types/react-css-modules/index.d.ts
+++ b/types/react-css-modules/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-css-modules 4.2.0
+// Type definitions for react-css-modules 4.6.0
 // Project: https://github.com/gajus/react-css-modules
 // Definitions by: Kostya Esmukov <https://github.com/KostyaEsmukov>, Tadas Dailyda <https://github.com/skirsdeda>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -6,7 +6,7 @@
 
 interface TypeOptions {
     allowMultiple?: boolean;
-    errorWhenNotFound?: boolean;
+    handleNotFoundStyleName?: 'throw' | 'log' | 'ignore';
 }
 
 type StylesObject = any;


### PR DESCRIPTION
A new released changed the interface.
See https://github.com/gajus/react-css-modules#options
and https://github.com/gajus/react-css-modules/releases/tag/v4.6.0

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/gajus/react-css-modules#options and https://github.com/gajus/react-css-modules/releases/tag/v4.6.0
- [x] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.
